### PR TITLE
RK-9901 - Update image to 2.7.2 as 2.7 latest is 2.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:2.7.2
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
CD failed, so I'll pin the ruby version
https://app.circleci.com/pipelines/github/Rookout/tutorial-ruby/67/workflows/4fc9cb42-460a-4712-8030-bd9396184f80/jobs/146/parallel-runs/0/steps/0-108