### PR TITLE
revert RK-12347

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.5
+FROM ruby:2.7.2
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
reverting https://github.com/Rookout/tutorial-ruby/pull/17 because we also need to update GEM:
`Your Ruby version is 2.7.5, but your Gemfile specified 2.7.2`